### PR TITLE
feat: C Replacement for `sample`, bootstrapping for `GainLoss`

### DIFF
--- a/R/ProtWeaver-PAPreds.R
+++ b/R/ProtWeaver-PAPreds.R
@@ -283,7 +283,7 @@ Behdenna.ProtWeaver <- function(pw, Subset=NULL, Verbose=TRUE,
     glmat[,i] <- abs(generateGainLossVec(fd, pap[,i], moveEventsUpward=useACCTRAN))
     if (Verbose) setTxtProgressBar(pb, i)
   }
-  
+  if (Verbose) cat('\n')
   vals <- calc_SId_mat(fd, IdOnly=!useSubtree)
   if (useSubtree)
     M <- vals$S
@@ -335,6 +335,7 @@ GainLoss.ProtWeaver <- function(pw, Subset=NULL,
     subs <- ProcessSubset(pw, Subset)
   uvals <- subs$uvals
   evalmap <- subs$evalmap
+  BOOTSTRAP_NUM <- 100L
 
   if (is.null(MySpeciesTree)){
     stopifnot("Method 'GainLoss' requires a species tree"=attr(pw, 'useMT'))
@@ -373,18 +374,31 @@ GainLoss.ProtWeaver <- function(pw, Subset=NULL,
     glvs[,i] <- glv
     if (Verbose) setTxtProgressBar(pb, i)
   }
+  if(Verbose) cat("\n")
   
-  ARGS <- list(allnonzero=allnonzero, y=y)
+  ARGS <- list(allnonzero=allnonzero, y=y, bsn=BOOTSTRAP_NUM)
   FXN <- function(v1, v2, ARGS, ii, jj){
     allnonzero <- ARGS$allnonzero
     if (allnonzero[ii] || allnonzero[jj]){
       return(0)
     } else {
       res <- .Call("calcScoreGL", ARGS$y, v1, v2)
-      #normer <- mean(sum(abs(v1)), sum(abs(v2)))
-      normer <- sum(abs(v1), abs(v2))
-      normer <- ifelse(normer==0, 1, normer)
-      return(2*res / normer)
+      if (res==0) return(0)
+      num_bs <- ARGS$bsn
+      if(num_bs > 0){
+        replicates <- rep(NA_real_, num_bs)
+        for(i in seq_len(num_bs)){
+          replicates[i] <- abs(.Call("calcScoreGL", ARGS$y, sample(v1), (v2)))
+        }
+        pv <- sum(replicates <= abs(res)) / num_bs
+        res <- pv*res
+      } else{
+        normer <- mean(sum(abs(v1)), sum(abs(v2)))
+        normer <- sum(abs(v1), abs(v2))
+        normer <- ifelse(normer==0, 1, normer)
+        res <- 2*res / normer
+      }
+      return(res)
     }
   }
   pairscores <- BuildSimMatInternal(glvs, uvals, evalmap, l, names(pw), 

--- a/R/ProtWeaver-PAPreds.R
+++ b/R/ProtWeaver-PAPreds.R
@@ -375,8 +375,8 @@ GainLoss.ProtWeaver <- function(pw, Subset=NULL,
     if (Verbose) setTxtProgressBar(pb, i)
   }
   if(Verbose) cat("\n")
-  
-  ARGS <- list(allnonzero=allnonzero, y=y, bsn=BOOTSTRAP_NUM)
+  lenglv <- nrow(glvs)
+  ARGS <- list(allnonzero=allnonzero, y=y, bsn=BOOTSTRAP_NUM, l=lenglv)
   FXN <- function(v1, v2, ARGS, ii, jj){
     allnonzero <- ARGS$allnonzero
     if (allnonzero[ii] || allnonzero[jj]){
@@ -386,9 +386,14 @@ GainLoss.ProtWeaver <- function(pw, Subset=NULL,
       if (res==0) return(0)
       num_bs <- ARGS$bsn
       if(num_bs > 0){
+        v1 <- as.integer(v1)
+        v2 <- as.integer(v2)
+        l <- as.integer(ARGS$l)
         replicates <- rep(NA_real_, num_bs)
         for(i in seq_len(num_bs)){
-          replicates[i] <- abs(.Call("calcScoreGL", ARGS$y, sample(v1), (v2)))
+          replicates[i] <- abs(.Call("calcScoreGL", ARGS$y, 
+                                     .C("shuffleRInt", v1, l)[[1]],
+                                     .C("shuffleRInt", v2, l)[[1]]))
         }
         pv <- sum(replicates <= abs(res)) / num_bs
         res <- pv*res

--- a/R/ShuffleC.R
+++ b/R/ShuffleC.R
@@ -1,0 +1,11 @@
+ShuffleC <- function(vec){
+  l <- length(vec)
+  stopifnot(l > 0)
+  if(l==1) return(vec)
+  
+  if(is(vec, 'integer')){
+    return(.C("shuffleRInt", vec, l)[[1]])
+  } else {
+    return(vec[.C("shuffleRInt", seq_len(l), l)[[1]]])
+  }
+}

--- a/src/CShuffle.h
+++ b/src/CShuffle.h
@@ -1,0 +1,4 @@
+#include "SEutils.h"
+
+/*** R .Call Functions ***/
+void shuffleRInt(int *v, int *l){ shuffle(int, v, *l); }

--- a/src/R_init_synextend.c
+++ b/src/R_init_synextend.c
@@ -24,6 +24,9 @@
 // SynExtend header file
 #include "SynExtend.h"
 
+// Other header files for .C Routines
+#include "CShuffle.h"
+
 /*
  * -- REGISTRATION OF THE .Call ENTRY POINTS ---
  */
@@ -54,6 +57,8 @@ static const R_CallMethodDef callMethods[] = { // method call, pointer, num args
  */
 static const R_CMethodDef cMethods[] = {
   {"cleanupFxn", (DL_FUNC) &cleanupFxn, 0},
+  {"shuffleRInt", (DL_FUNC) &shuffleRInt, 2},
+  {"shuffleRDouble", (DL_FUNC) &shuffleRInt, 2},
   {NULL, NULL, 0}
 };
 

--- a/src/SEutils.c
+++ b/src/SEutils.c
@@ -24,7 +24,8 @@ void shuffle_int_(int *x, int n){
 }
 
 void shuffle_uint_(uint *x, int n){
-  int j, tmp;
+  int j;
+  uint tmp;
   for (int i=(n-1); i>0; i--){
     j = irand() % (i+1);
     tmp = x[j];
@@ -35,7 +36,8 @@ void shuffle_uint_(uint *x, int n){
 
 
 void shuffle_double_(double *x, int n){
-  int j, tmp;
+  int j;
+  double tmp;
   for (int i=(n-1); i>0; i--){
     j = irand() % (i+1);
     tmp = x[j];
@@ -45,7 +47,8 @@ void shuffle_double_(double *x, int n){
 }
 
 void shuffle_char_(char *x, int n){
-  int j, tmp;
+  int j;
+  char tmp;
   for (int i=(n-1); i>0; i--){
     j = irand() % (i+1);
     tmp = x[j];


### PR DESCRIPTION
Adds new `ShuffleC` function to shuffle a vector, performance is roughly 6x faster than base R for integer vectors and around 4x faster for everything else.

Also implements a bootstrapping test for p-values for `GainLoss` function

```
Unit: microseconds
               expr      min        lq      mean   median       uq      max neval
  BaseRShuffleInt() 3172.580 3265.8960 3358.8303 3328.811 3414.132 4206.764   100
      ShuffleCInt()  493.804  506.3910  540.3874  528.818  544.890 1256.732   100
 BaseRShuffleReal() 3100.256 3195.6630 3308.9378 3280.533 3384.960 4330.174   100
     ShuffleCReal()  764.117  805.3425  851.9226  840.131  868.708 1491.129   100
```