### PR TITLE
feat: Sampling with replacement, reproducibility

### DIFF
--- a/R/ShuffleC.R
+++ b/R/ShuffleC.R
@@ -1,9 +1,19 @@
-ShuffleC <- function(vec, n=length(vec)){
-  stopifnot(n > 0 && n <= length(vec))
+ShuffleC <- function(vec, n=length(vec), replace=FALSE){
+  stopifnot(n > 0 && (replace || n <= length(vec)))
+  if (replace)
+    return(ShuffleWithRecomb(vec, n))
+  
   trimlen <- seq_len(n)
   if(is(vec, 'integer')){
     return(.C("shuffleRInt", vec, n)[[1]][trimlen])
   } else {
     return(vec[.C("shuffleRInt", seq_len(length(vec)), n)[[1]]][trimlen])
   }
+}
+
+ShuffleWithRecomb <- function(vec, n=length(vec)){
+  n <- as.integer(n)
+  l <- length(vec)
+  idxes <- .C("shuffleRRepl", seq_len(n), n)[[1L]] %% l + 1L
+  return(vec[idxes])
 }

--- a/src/CShuffle.c
+++ b/src/CShuffle.c
@@ -1,0 +1,33 @@
+#include <R.h>
+#include <Rdefines.h>
+#include <R_ext/Rdynload.h>
+#include <R_ext/Utils.h>
+#include <R_ext/Random.h>
+#include <Rinternals.h>
+#include <math.h>
+#include <stdlib.h>
+#include <stdbool.h>
+
+#include "SynExtend.h"
+#include "SEutils.h"
+
+/*** R .C Functions ***/
+void shuffleRInt(int *v, int *l){ 
+  GetRNGstate();
+  shuffle(int, v, *l); 
+  PutRNGstate();
+}
+
+void shuffleRRepl(int *v, int *l){ 
+  GetRNGstate();
+  struct RNGstate32 *r = malloc(sizeof(struct RNGstate32));
+  uint64_t seed = (((uint64_t)irand()) << 32) | ((uint64_t)irand());
+  seedRNGState32(r, seed);
+  for (int i=0; i<*l; i++)
+    v[i] = (xorshift32b(r) >> 1);
+
+  PutRNGstate();
+  return;
+}
+
+

--- a/src/CShuffle.h
+++ b/src/CShuffle.h
@@ -1,4 +1,0 @@
-#include "SEutils.h"
-
-/*** R .Call Functions ***/
-void shuffleRInt(int *v, int *l){ shuffle(int, v, *l); }

--- a/src/R_init_synextend.c
+++ b/src/R_init_synextend.c
@@ -25,7 +25,7 @@
 #include "SynExtend.h"
 
 // Other header files for .C Routines
-#include "CShuffle.h"
+#include "SEutils.h"
 
 /*
  * -- REGISTRATION OF THE .Call ENTRY POINTS ---
@@ -58,7 +58,7 @@ static const R_CallMethodDef callMethods[] = { // method call, pointer, num args
 static const R_CMethodDef cMethods[] = {
   {"cleanupFxn", (DL_FUNC) &cleanupFxn, 0},
   {"shuffleRInt", (DL_FUNC) &shuffleRInt, 2},
-  {"shuffleRDouble", (DL_FUNC) &shuffleRInt, 2},
+  {"shuffleRRepl", (DL_FUNC) &shuffleRRepl, 2},
   {NULL, NULL, 0}
 };
 

--- a/src/SEutils.h
+++ b/src/SEutils.h
@@ -1,3 +1,6 @@
+#ifndef UTIL_FILE
+#define UTIL_FILE
+
 // Various utility functions
 #include <stdlib.h>
 #include <math.h>
@@ -65,10 +68,11 @@ void seedRNGState32(struct RNGstate32 *r, uint64_t seed);
 
 uint32_t xorshift32b(struct RNGstate32 *r);
 
-
 /*** Random math functions ***/
 long inline doubleFactorial(int n){
   long retval = 1;
   while (n > 0) retval *= n--;
   return retval;
 }
+
+#endif

--- a/src/SynExtend.h
+++ b/src/SynExtend.h
@@ -32,3 +32,9 @@ SEXP calcDBrownValue(SEXP tnPtr, SEXP allLabels, SEXP iterNum, SEXP SD, SEXP STA
 SEXP pseudoRandomSample(SEXP N);
 SEXP randomProjection(SEXP VEC, SEXP NONZERO, SEXP N, SEXP OUTDIM);
 SEXP seededPseudoRandomSample(SEXP N, SEXP SEED);
+
+
+/**** CShuffle.c ****/
+void shuffleRInt(int *v, int *l);
+
+void shuffleRRepl(int *v, int *l);


### PR DESCRIPTION
Adds ability to use `set.seed`, as well as sampling with replacement. No support for custom probabilities, use `sample` for that. Some internal code refactoring as well.

Performance (integer sampling, double sampling, sampling with replacement):
```
Unit: microseconds
               expr      min        lq      mean    median        uq      max neval
  BaseRShuffleInt() 1633.932 1710.2740 1846.6900 1755.3740 1811.4620 62758.66  1000
      ShuffleCInt()  349.320  370.4555  471.5713  408.0525  434.0055 48016.17  1000
 BaseRShuffleReal() 1593.137 1660.0080 1790.4891 1702.2175 1765.6855 59973.28  1000
     ShuffleCReal()  550.015  588.2065  762.1743  689.7430  742.7355 48088.12  1000
 BaseRShuffleRepl() 3694.715 3823.6190 4053.6885 3915.2745 4024.9085 57754.53  1000
     ShuffleCRepl() 1370.015 1452.6300 1829.3653 1633.8500 1749.4085 48398.33  1000
```